### PR TITLE
Allow ssl to be ignored when loading from environ.

### DIFF
--- a/missioncontrol_client/__init__.py
+++ b/missioncontrol_client/__init__.py
@@ -212,8 +212,10 @@ def handle_default_args(args):
     else:
         args.mc_api.login(username=args.username, password=args.password)
 
-def from_environ():
+def from_environ(ignore_ssl=False):
     mc_api = MCAPI(os.environ['MC_BASE'])
+    if ignore_ssl:
+        mc_api.s.verify = False
     if os.environ.get('MC_JWT'):
         mc_api.login(jwt=os.environ['MC_JWT'])
     else:


### PR DESCRIPTION
Specifically don't allow ssl_ignore to be based on an environment variable, but you can choose to explicitly disable it when calling `from_environ` as a kwarg.